### PR TITLE
Let MongoDB finish starting up, before attempting to connect

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+# Let MongoDB start properly
+sleep 5
+
 npx screeps start --steam_api_key="$STEAM_API_KEY"


### PR DESCRIPTION
Screeps attempts to connect to MongoDB before the DB has finished starting, and it does not retry. This leads to the server being stuck.